### PR TITLE
klee-log-parser.sh: change output format

### DIFF
--- a/klee-log-parser.sh
+++ b/klee-log-parser.sh
@@ -8,13 +8,14 @@ fi
 
 for file in $FILES; do
 #	grep -q 'LastChar > FirstChar' $file && echo -n X
-	grep -q 'query timed out (resolve)' $file && echo -n H
-	grep -q 'HaltTimer invoked' $file && echo -n H
-	grep -q 'failed external call' $file && echo -n E
-	grep -q 'ERROR: unable to load symbol' $file && echo -n G
-	grep -qE 'memory error|invalid function pointer' $file && echo -n M
-	grep -q 'LLVM ERROR: Code generator does not support' $file && echo -n I
-	grep -q 'klee: .*Assertion .* failed.' $file && echo -n C
-	grep -q 'ASSERTION FAIL' $file && echo -n B
-	echo " $file"
+	grep -q 'query timed out (resolve)' $file && echo -n 'ESTPTIMEOUT '
+	grep -q 'HaltTimer invoked' $file && echo -n 'EKLEETIMEOUT '
+	grep -q 'failed external call' $file && echo -n 'EEXTERNCALL '
+	grep -q 'ERROR: unable to load symbol' $file && echo -n 'ELOADSYM '
+	grep -qE 'memory error|invalid function pointer' $file && echo -n 'EINVALPTR '
+	grep -q 'LLVM ERROR: Code generator does not support' $file && echo -n 'EINVALINST '
+	grep -q 'klee: .*Assertion .* failed.' $file && echo -n 'EKLEEASSERT '
+	grep -q 'ASSERTION FAIL' $file && echo -n 'ASSERTIONFAILED '
+
+	echo "$file"
 done


### PR DESCRIPTION
give more human-readable messages

New version of scripts (pull-request will follow-up for svc13) use this format.
